### PR TITLE
fix(calendar): make disabled date cannot click

### DIFF
--- a/src/components/calendar/date-table.vue
+++ b/src/components/calendar/date-table.vue
@@ -233,6 +233,9 @@ export default {
       })
     },
     selectDay (item) {
+      if (this.isDateDisabled(item)) {
+        return;
+      }
       const canSelPrevMonthDay = item.class === 'lastmonth' &&
         !(this.prevMonth() === false)
       const canSelNextMonthDay = item.class === 'nextmonth' &&

--- a/src/components/calendar/date-table.vue
+++ b/src/components/calendar/date-table.vue
@@ -234,7 +234,7 @@ export default {
     },
     selectDay (item) {
       if (this.isDateDisabled(item)) {
-        return;
+        return
       }
       const canSelPrevMonthDay = item.class === 'lastmonth' &&
         !(this.prevMonth() === false)


### PR DESCRIPTION
bug: 当日历组件传了minDate或者maxDate时，产生的行为是相对应的date被置为disabled状态，此时点击disabled date，仍可获取值。 
fix: 点击disabled date，对click事件不做响应