### PR TITLE
chore: fix scripts error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_script:
 
 after_success:
   - test $TRAVIS_PULL_REQUEST = "false" && \
-    test $TRAVIS_BRANCH" = "master" && \
+    test $TRAVIS_BRANCH = "master" && \
     npx travis-deploy-once "npx semantic-release"
 branches:
   except:

--- a/scripts/prestart.sh
+++ b/scripts/prestart.sh
@@ -10,7 +10,7 @@ DIR_NAME=${0%/*}
 while true; do
   read -p "Do you want to sync local repo with upstream?" yn
   case $yn in
-    [Yy]* ) ${DIR_NAME}/git-sync-fork.sh upstream origin; break;;
+    [Yy]* ) ${DIR_NAME}/sync-upstream.sh; break;;
     [Nn]* ) exit;;
     * ) echo "Please answer yes or no.";;
   esac


### PR DESCRIPTION
修正错误

1. travis 配置字符问题
2. prestart.sh 还是调用 sync-upstream.sh比较好