### PR TITLE
fix and enhance some components (icon/select), update documentation

### DIFF
--- a/docs/plugins/dom.js
+++ b/docs/plugins/dom.js
@@ -1,0 +1,9 @@
+export default {
+  install () {
+    if (typeof window !== 'undefined') {
+      if (/windows/i.test(navigator.userAgent)) {
+        document.documentElement.classList.add('is-windows')
+      }
+    }
+  }
+}

--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -222,17 +222,19 @@ footer a {
 }
 
 /* scrollbar */
-::-webkit-scrollbar {
-  background-color: transparent;
-  width: 6px;
-  height: 6px;
-}
+.is-windows {
+  ::-webkit-scrollbar {
+    background-color: transparent;
+    width: 6px;
+    height: 6px;
+  }
 
-::-webkit-scrollbar-thumb {
-  background-color: rgba(50, 50, 50, 0.65);
-  background-repeat: no-repeat;
-  background-position: center center;
-  border-radius: 3px;
+  ::-webkit-scrollbar-thumb {
+    background-color: rgba(50, 50, 50, 0.65);
+    background-repeat: no-repeat;
+    background-position: center center;
+    border-radius: 3px;
+  }
 }
 
 .hljs {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jest-puppeteer": "^3.3.1",
     "jest-serializer-vue": "^2.0.2",
     "lint-staged": "^8.1.0",
-    "pholio": "^0.3.1",
+    "pholio": "^0.4.1",
     "postcss-cli": "^6.0.0",
     "postcss-cssnext": "^3.0.2",
     "postcss-each": "^0.10.0",

--- a/pholio.config.js
+++ b/pholio.config.js
@@ -18,6 +18,9 @@ module.exports = {
   externals: [
     'https://lib.baomitu.com/font-awesome/4.7.0/css/font-awesome.min.css',
     'https://lib.baomitu.com/babel-polyfill/6.26.0/polyfill.min.js',
-    'https://lib.baomitu.com/fetch/2.0.3/fetch.min.js'
+    'https://lib.baomitu.com/fetch/2.0.3/fetch.min.js',
+    // the following two files are helpers
+    'https://lib.baomitu.com/clipboard.js/1.7.1/clipboard.min.js',
+    'https://lib.baomitu.com/yamljs/0.3.0/yaml.min.js'
   ]
 }

--- a/src/components/icon/index.md
+++ b/src/components/icon/index.md
@@ -2,6 +2,18 @@
 title: 图标
 layout: component
 route: /component/icon
+meta:
+  script:
+    - src: https://lib.baomitu.com/clipboard.js/1.7.1/clipboard.min.js
+    - src: https://lib.baomitu.com/yamljs/0.3.0/yaml.min.js
+  link:
+    -
+      href: https://lib.baomitu.com/font-mfizz/2.4.1/font-mfizz.min.css
+      rel: stylesheet
+    -
+      href: https://lib.baomitu.com/material-design-icons/3.0.1/iconfont/material-icons.css
+      rel: stylesheet
+
 ---
 
 # 字体图标
@@ -11,7 +23,7 @@ route: /component/icon
 如需使用其他类型的图标，请**自行引入** 相关 CSS 和字体，如 [FontAwesome](http://fontawesome.io/icons/)：
 
 ```xml
-<link href="https://lib.baomitu.com/font-awesome/4.7.0/css/font-awesome.min.css" />
+<link href="https://lib.baomitu.com/font-awesome/4.7.0/css/font-awesome.min.css"  rel="stylesheet" />
 ```
 
 ## 效果展示
@@ -25,20 +37,21 @@ route: /component/icon
 
 像 FontAwesome 这种外部图标的使用，是通过 `<i>` 标签及其 class 值 `{类型} {类型}-{图标名}` 实现的。例如，根据 [font-mfizz](http://fizzed.com/oss/font-mfizz/) 的文档，图标使用方式为 `<i class="icon-angular"></i>`，则使用方法如下：
 
-<!-- 引入 CSS -->
-<link href="https://lib.baomitu.com/font-mfizz/2.4.1/font-mfizz.min.css" rel="stylesheet" />
-
 ```html
-<c-icon type="icon" name="angular" color="red" size="3em" valign="middle" />
-<c-icon type="icon" name="reactjs" color="blue" size="3em" valign="middle" />
-<c-button primary>
-  <c-icon type="icon" name="angular" />
-  <span>测试</span>
-</c-button>
+<div class="custom-icons">
+  <c-icon type="icon" name="angular" color="red" size="3em" valign="middle" />
+
+  <c-icon type="icon" name="reactjs" color="blue" size="3em" valign="middle" />
+
+  <c-button primary>
+    <c-icon type="icon" name="angular" />
+    <span>测试</span>
+  </c-button>
+</div>
 
 <style>
   /* 请自行引入 font-mfizz.css */
-  .c-icon, button {
+  .custom-icons .c-icon {
     margin-right: 20px;
   }
 </style>
@@ -46,8 +59,6 @@ route: /component/icon
 
 另外，还能兼容使用了 [ligature](https://alistapart.com/article/the-era-of-symbol-fonts) 技术的字体图标（如 [Material Icons](https://google.github.io/material-design-icons/#what-are-material-icons-)）。
 
-<!-- 引入 CSS -->
-<link href="https://lib.baomitu.com/material-design-icons/3.0.1/iconfont/material-icons.css" rel="stylesheet" />
 
 ```html
 <c-icon
@@ -120,33 +131,15 @@ route: /component/icon
 
 <script>
   const hoverClass = 'is-bg-gray-1'
-  const fetchJSON = url => fetch(url).then(r => r.json())
-  const loadScript = function (src) {
-    var s = document.createElement('script')
-    s.async = true
-    s.src = src
-    document.body.appendChild(s)
-    return new window.Promise(function (resolve, reject) {
-      s.onload = resolve
-      s.onerror = reject
-    })
-  }
-
   export default {
     data () {
       return {
-        icons: []
+        icons: Object.keys(this.$featherIcons).map(name => name.replace('feather-', ''))
       }
     },
 
     mounted () {
-      Promise.all([
-        fetchJSON('https://unpkg.com/feather-icons/dist/icons.json'),
-        loadScript('https://lib.baomitu.com/clipboard.js/1.7.1/clipboard.min.js')
-      ]).then(([obj]) => {
-        this.icons = window.Object.keys(obj)
-        new window.Clipboard('.icon-item')
-      })
+      new window.Clipboard('.icon-item')
     },
 
     methods: {
@@ -205,17 +198,6 @@ route: /component/icon
 
 <script>
   const hoverClass = 'is-bg-gray-1'
-  const fetchText = url => fetch(url).then(r => r.text())
-  const loadScript = function (src) {
-    var s = document.createElement('script')
-    s.async = true
-    s.src = src
-    document.body.appendChild(s)
-    return new window.Promise(function (resolve, reject) {
-      s.onload = resolve
-      s.onerror = reject
-    })
-  }
 
   export default {
     data () {
@@ -225,12 +207,9 @@ route: /component/icon
     },
 
     mounted () {
-      Promise.all([
-        fetchText('https://raw.githubusercontent.com/' +
-          'FortAwesome/Font-Awesome/37a838af4ddf679b566b0043ba9ebb45af36571e/src/icons.yml'),
-        loadScript('https://lib.baomitu.com/yamljs/0.3.0/yaml.min.js'),
-        loadScript('https://lib.baomitu.com/clipboard.js/1.7.1/clipboard.min.js')
-      ]).then(([text]) => {
+      const url = 'https://raw.githubusercontent.com/FortAwesome/Font-Awesome/37a838af4ddf679b566b0043ba9ebb45af36571e/src/icons.yml'
+
+      fetch(url).then(r => r.text()).then(text => {
         this.icons = window.YAML.parse(text).icons.map(i => i.id)
         new window.Clipboard('.icon-item')
       })

--- a/src/components/icon/index.md
+++ b/src/components/icon/index.md
@@ -3,9 +3,6 @@ title: 图标
 layout: component
 route: /component/icon
 meta:
-  script:
-    - src: https://lib.baomitu.com/clipboard.js/1.7.1/clipboard.min.js
-    - src: https://lib.baomitu.com/yamljs/0.3.0/yaml.min.js
   link:
     -
       href: https://lib.baomitu.com/font-mfizz/2.4.1/font-mfizz.min.css
@@ -13,7 +10,6 @@ meta:
     -
       href: https://lib.baomitu.com/material-design-icons/3.0.1/iconfont/material-icons.css
       rel: stylesheet
-
 ---
 
 # 字体图标
@@ -208,7 +204,6 @@ meta:
 
     mounted () {
       const url = 'https://raw.githubusercontent.com/FortAwesome/Font-Awesome/37a838af4ddf679b566b0043ba9ebb45af36571e/src/icons.yml'
-
       fetch(url).then(r => r.text()).then(text => {
         this.icons = window.YAML.parse(text).icons.map(i => i.id)
         new window.Clipboard('.icon-item')

--- a/src/components/select/index.md
+++ b/src/components/select/index.md
@@ -38,6 +38,34 @@ export default {
 </script>
 ```
 
+### 弹出选项是否覆盖
+
+select 组件触发后，弹出的选项默认会覆盖在选择框上。但有时候产品并不想要这种效果。这时候可以通过`shouldMenuOverlap` 属性（`should-menu-overlap`）加以调整。下面分别是两种不同的效果：
+
+```html
+
+<c-select v-model="dim" :options="options" />
+<c-select v-model="dim" :options="options" :should-menu-overlap="false" />
+
+<script>
+export default {
+  data () {
+    return {
+      dim: '',
+      options: [
+        { label: '浏览量', value: 'pv' },
+        { label: '访客数', value: 'uv' },
+        { label: '新访客数', value: 'nv' },
+        { label: '访问时长', value: 'du' },
+        { label: '转化次数', value: 'cv' },
+        { label: 'IP 数', value: 'ip' }
+      ]
+    }
+  }
+}
+</script>
+```
+
 ### 多选
 
 给 `c-select` 添加 `multiple` 属性可以将其设置为多选。在多选时，`v-model` 绑定的值是一个数组。

--- a/src/components/select/index.vue
+++ b/src/components/select/index.vue
@@ -8,6 +8,7 @@
   :tabindex="disabled ? -1 : 0"
   :class="classNames"
   @keydown="onKeyDown"
+  @keydown.tab="onTabOut"
   @click="toggleOpen"
 )
   i.c-select__caret
@@ -463,6 +464,12 @@ export default {
 
     onDeleteKey (e) {
       if (!this.query) this.selectedOptions.pop()
+    },
+
+    // 通过 Tab 键跳到下一个焦点
+    // 理应关闭弹出菜单
+    onTabOut () {
+      this.close()
     },
 
     onKeyDown (e) {

--- a/src/components/select/index.vue
+++ b/src/components/select/index.vue
@@ -324,12 +324,36 @@ export default {
   },
 
   methods: {
+    /**
+     * SEE https://github.com/clair-design/clair/issues/40
+     * 1. should not focus on `this.$el` if we just clicked another
+     *    element that is focusable
+     * 2. should not set focus on `this.$el` if it's gone out of screen,
+     *    at least, prevent `this.$el` from scrolling into visible area,
+     *    which can cause the page jumping/flashing
+     *
+     * @param {HTMLElement} target the element that may be focused
+     */
+    setFocusIfPossible (target) {
+      const activeElement = document.activeElement
+      // https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement
+      // "When there is no selection, the active element is the page's <body> or null".
+      if (activeElement !== document.body) {
+        // SEE https://stackoverflow.com/a/51746983
+        if (activeElement.contains(target) || activeElement === target) {
+          return
+        }
+      }
+      // SEE https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
+      this.$el.focus({ preventScroll: true })
+    },
+
     toggleOpen () {
       if (this.disabled) return
       if (this.isOpen) {
         this.close()
       } else {
-        this.open()
+        this.$nextTick(this.open)
       }
     },
 
@@ -363,7 +387,7 @@ export default {
 
     focusOnInput () {
       this.$nextTick(() => {
-        this.$refs.input.focus()
+        this.$refs.input.focus({ preventScroll: true })
       })
     },
 
@@ -453,12 +477,12 @@ export default {
       menuEl.style.zIndex = zIndex.next()
     },
 
-    onBodyClick (e) {
-      const isInSelect = this.$el.contains(e.target)
-      const isInMenu = this.menuEl.contains(e.target)
+    onBodyClick ({ target }) {
+      const isInSelect = this.$el.contains(target)
+      const isInMenu = this.menuEl.contains(target)
       if (!isInSelect && !isInMenu) {
         this.close()
-        this.$el.focus()
+        this.setFocusIfPossible(target)
       }
     },
 

--- a/src/components/select/position.js
+++ b/src/components/select/position.js
@@ -1,17 +1,22 @@
-/**
- * get absolute position relative to another element
- */
 export const POSITION = {
   TOP: 'top',
   BOTTOM: 'bottom'
 }
-export function getPosition (el, refEl, pos = POSITION.TOP) {
-  const refRect = refEl.getBoundingClientRect()
-  const refTop = refRect.top + window.pageYOffset
-  const refLeft = refRect.left + window.pageXOffset
-  const left = refLeft
-  const top = pos === POSITION.TOP ? refTop : refTop + refEl.clientHeight
-  return { left, top }
+
+/**
+ * get absolute position relative to another element
+ */
+export function getPosition (el, refEl) {
+  const { top, left, width, height } = refEl.getBoundingClientRect()
+  const refTop = top + window.pageYOffset
+  const refLeft = left + window.pageXOffset
+
+  return {
+    width,
+    height,
+    left: refLeft,
+    top: refTop
+  }
 }
 
 export default { getPosition }

--- a/src/components/tree/tree-node.vue
+++ b/src/components/tree/tree-node.vue
@@ -17,7 +17,7 @@
     )
     .c-tree__label
       c-node-label(:node="node")
-  .c-tree_children(v-show="showChildren")
+  .c-tree_children(v-if="hasChildren", v-show="showChildren")
     c-tree-node(
       ref="children"
       v-for="(child, index) in node.children"

--- a/src/scripts/components.js
+++ b/src/scripts/components.js
@@ -1,3 +1,4 @@
+import { pascalCase } from './utils/index'
 // NOTE
 // `require.context` must be treated as a whole. by
 // NO means you should split them up, as is required
@@ -10,16 +11,16 @@ export default {
     const keys = reqs.keys()
     for (let i = 0; i < keys.length; i++) {
       const module = getModule(reqs(keys[i]))
-      module.name && Vue.component(module.name, module)
+
+      // turn components' names to Pascal Case
+      // so that we can use markups like `<CSelect />`
+      // which would meet the needs of those PascalCase fans
+      // TODO
+      // we will turn all `name` fields in SFC into pacal case in the future
+      module.name && Vue.component(pascalCase(module.name), module)
     }
   }
 }
-
-// function importAll (r) {
-//   return reqs.keys().map(key => {
-//     return getModule(reqs(key))
-//   })
-// }
 
 function getModule (module) {
   return (module.__esModule && module.default) || module

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -1,3 +1,5 @@
+import featherIcons from 'feather-vue'
+
 // plugins
 import Components from './components'
 
@@ -14,8 +16,22 @@ const mixins = { validatable, resettable }
 export const Clair = {
   mixins,
   install (Vue) {
+    const VuePrototype = Vue.prototype
+    const defineReadOnly = function (key, val) {
+      Object.defineProperty(VuePrototype, key, {
+        get () {
+          return val
+        },
+        configurable: process.env.NODE_ENV !== 'production',
+        enumerable: false
+      })
+    }
+
+    // set a noop utility
+    defineReadOnly('noop', _ => _)
+
     // inject $clair to Vue prototype
-    if (!('$clair' in Vue.prototype)) {
+    if (!('$clair' in VuePrototype)) {
       const $clair = new Vue({
         data: {
           responsive: null,
@@ -23,18 +39,15 @@ export const Clair = {
         }
       })
       $clair.mixins = mixins
-
-      Object.defineProperty(Vue.prototype, '$clair', {
-        get () {
-          return $clair
-        }
-      })
+      defineReadOnly('$clair', $clair)
     }
 
-    Vue.prototype.noop = () => {}
+    // expose featherIcons for convenience
+    defineReadOnly('$featherIcons', featherIcons)
 
     // register components
     Vue.use(Components)
+
     // install plugins
     Vue.use(Modal)
     Vue.use(Responsive)

--- a/src/scripts/utils/index.js
+++ b/src/scripts/utils/index.js
@@ -3,6 +3,15 @@ import zIndexManager from './zIndexManager'
 export { VueTypes }
 
 /**
+ * pretty simple pascalCase function
+ *
+ * @param {String} str
+ */
+export function pascalCase (str) {
+  return str.replace(/(^|-)([a-z])/g, (_, __, g2) => g2.toUpperCase())
+}
+
+/**
  * @desc get Vue Constructor inside Vue instances
  * @param vm {VueComponent} Vue instance
  */


### PR DESCRIPTION
具体情况见  commit message。大致如下：

## fix: register components with PascalCase,
so that we can use markups like `<CSelect />`, which would meet the needs of those PascalCase fans

## fix: expose featherIcons to Vue prototype

## fix(tree): recursive components

tree errors with Vue@2.5.18+

## docs(style): no need to set scrollbar styles on mac

## docs(icon): 重写部分demo, 修复 feather icon 与最新版不同步的问题

## fix(select): 下拉效果

1. 菜单项位置可通过`shouldMenuOverlap`配置

2. 修复多选可过滤的下拉框位置错误问题

3. 非输入类型情况下，无值时下拉展示placehodler

## fix(select): 通过 Tab 键跳到下一个焦点时关闭弹出菜单
## fix(select): select component's focusing issues
## fix(select): 通过 Tab 键跳到下一个焦点时关闭弹出菜单
